### PR TITLE
add host alias from ~/.ssh/config to bash autocomplete

### DIFF
--- a/.bash_autocomplete
+++ b/.bash_autocomplete
@@ -4,3 +4,4 @@ BASH_UTILS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "$BASH_UTILS_DIR/.bash_autocomplete_hub"
 source "$BASH_UTILS_DIR/.bash_autocomplete_npm"
+source "$BASH_UTILS_DIR/.bash_autocomplete_ssh"

--- a/.bash_autocomplete_ssh
+++ b/.bash_autocomplete_ssh
@@ -1,0 +1,8 @@
+_ssh() 
+{
+    local cur use
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    use=$(grep '^Host' ~/.ssh/config ~/.ssh/config.d/* 2>/dev/null | grep -v '[?*]' | cut -d ' ' -f 2-)
+    COMPREPLY=( $(compgen -W "$use" -- ${cur}) )
+}
+complete -F _ssh ssh


### PR DESCRIPTION
This is kind of an opinionated autocomplete - the existing ssh autocompletion autocompletes out of known_hosts, which is trash. I want my aliased hosts out of my config file.